### PR TITLE
Add ca-certificates to Docker images.

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,6 +1,8 @@
 FROM alpine:3.5
 MAINTAINER Francis Chuang <francis.chuang@boostport.com>
 
+RUN apk --update add ca-certificates && update-ca-certificates
+
 RUN mkdir -p /kubernetes-vault
 
 ADD kubernetes-vault /bin/kubernetes-vault

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -1,6 +1,8 @@
 FROM alpine:3.5
 MAINTAINER Francis Chuang <francis.chuang@boostport.com>
 
+RUN apk --update add ca-certificates && update-ca-certificates
+
 ADD kubernetes-vault-init /kubernetes-vault-init
 
 ENTRYPOINT ["/kubernetes-vault-init"]


### PR DESCRIPTION
We're using an external CA to secure our Vault installation and I couldn't get it to connect - gave this error:

```
time="2017-05-02T15:39:33Z" level=fatal msg="Could not create the vault client: error parsing supplied token: failed to lookup Vault periodic token: Get https://vault.saws.io/v1/auth/token/lookup-self: x509: failed to load system roots and no roots provided"
```

Adding the ca-certificates fixed that problem.