### PR TITLE
Get certificate expiry from the certificate rather than Vault's lease

### DIFF
--- a/deployments/quick-start/kubernetes-vault.yaml
+++ b/deployments/quick-start/kubernetes-vault.yaml
@@ -48,7 +48,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-vault
-        image: boostport/kubernetes-vault:0.4.3
+        image: boostport/kubernetes-vault:0.4.4
         env:
         - name: KUBERNETES_NAMESPACE
           valueFrom:

--- a/deployments/quick-start/sample-app.yaml
+++ b/deployments/quick-start/sample-app.yaml
@@ -14,7 +14,7 @@ spec:
         pod.beta.kubernetes.io/init-containers: '[
           {
             "name": "install",
-            "image": "boostport/kubernetes-vault-init:0.4.3",
+            "image": "boostport/kubernetes-vault-init:0.4.4",
             "imagePullPolicy": "Always",
             "env": [
                 {
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: sample-app
-        image: boostport/kubernetes-vault-sample-app:0.4.3
+        image: boostport/kubernetes-vault-sample-app:0.4.4
         volumeMounts:
         - name: vault-token
           mountPath: /var/run/secrets/boostport.com

--- a/deployments/secured-external-ca/kubernetes-vault.yaml
+++ b/deployments/secured-external-ca/kubernetes-vault.yaml
@@ -147,7 +147,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-vault
-        image: boostport/kubernetes-vault:0.4.3
+        image: boostport/kubernetes-vault:0.4.4
         imagePullPolicy: Always
         env:
         - name: KUBERNETES_NAMESPACE

--- a/deployments/secured-external-ca/sample-app.yaml
+++ b/deployments/secured-external-ca/sample-app.yaml
@@ -14,7 +14,7 @@ spec:
         pod.beta.kubernetes.io/init-containers: '[
           {
             "name": "install",
-            "image": "boostport/kubernetes-vault-init:0.4.3",
+            "image": "boostport/kubernetes-vault-init:0.4.4",
             "imagePullPolicy": "Always",
             "env": [
                 {
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: sample-app
-        image: boostport/kubernetes-vault-sample-app:0.4.3
+        image: boostport/kubernetes-vault-sample-app:0.4.4
         volumeMounts:
         - name: vault-token
           mountPath: /var/run/secrets/boostport.com


### PR DESCRIPTION
duration. This is because Vault 0.7.0's PKI certificates are unleased,
resulting in a duration of 0. This causes Kubernetes-Vault to think that
the certificate is expired, causing it to slam Vault for new certificates.