### PR TITLE
Use unwrapped secret id when not fetching token

### DIFF
--- a/init/main.go
+++ b/init/main.go
@@ -145,7 +145,7 @@ func main() {
 			} else {
 				response = secretID{
 					RoleID:    roleID,
-					SecretID:  wrappedSecretId.SecretID,
+					SecretID:  sID,
 					Accessor:  secretIDAccessor,
 					VaultAddr: wrappedSecretId.VaultAddr,
 				}


### PR DESCRIPTION
When setting `RETRIEVE_TOKEN` to `"false"`, this writes the still-wrapped secret to file. However, it has already been unwrapped, so there is no way to get the actual secret.