### PR TITLE
Feature/keep secret wrapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The token information is encoded as JSON and written to a file called `vault-tok
 }
 ```
 
-You application should parse the JSON representation and renew the `clientToken` using the `leaseDuration` as a guide.
+Your application should parse the JSON representation and renew the `clientToken` using the `leaseDuration` as a guide.
 
 If you ask the init container to not login using the `role_id` and `secret_id` to retrieve the token by setting the
 `RETRIEVE_TOKEN` environment variable of the init container to `false`, the `secret_id` and any related information is
@@ -54,6 +54,17 @@ encoded as JSON written to a file called `vault-secret-id` instead. Here's an ex
 
 If you choose to use Kubernetes-vault in this mode, it will be your application's responsibility to use the `secret_id`
 and `role_id` pair to login to the Vault server and retrieve an auth token.
+
+Alternatively, you can choose to not have the init container unwrap the secret, and leave that responsibility up to your app. To do this, set `UNWRAP_SECRET` to `false`, and the wrapped `secret_id` and any related information will be encoded as JSON and written to a file called `vault-wrapped-secret-id`. Here's an example of what it looks like:
+
+```json
+{
+   "roleId":"313b0821-4ff6-1df8-54dd-c3eea5d3b8b1",
+   "wrappedSecretId":"2179ad51-cfb5-03de-dad7-2c25746b38e3",
+   "vaultAddr":"https://vault:8200",
+   "ttl":60
+}
+```
 
 ## CA bundle
 If you are connecting to Vault over https (highly recommended for production), you will find the CA bundle for Vault in
@@ -196,6 +207,7 @@ The init containers are configured using environment variables and Kubernetes an
 | CREDENTIALS_PATH     | The location where the Vault token and CA Bundle (if it exists) will be written.                                                  | `no`     | `/var/run/secrets/boostport.com` | `/var/run/my/path`                     |
 | LOG_LEVEL            | The log level. Valid values are `debug` and `error`.                                                                              | `no`     | `debug`                          | `debug`                                |
 | RETRIEVE_TOKEN       | Whether to login using the `secret_id` and `role_id` to retrieve the auth token.                                                  | `no`     | `true`                           | `false`                                |
+| UNWRAP_SECRET        | Whether to unwrap the `secret_id`                                                                                                  | `no`     | `true`                           | `false`                                |
 | TIMEOUT              | Maximum amount of time to wait for the wrapped `secret_id` to be pushed. Valid time units are `ns`, `us`, `ms`, `s`, `m` and `h`. | `no`     | `5m`                             | `120s`                                 |
 | VAULT_ROLE_ID        | The Vault role id.                                                                                                                | `yes`    | `none`                           | `313b0821-4ff6-1df8-54dd-c3eea5d3b8b1` |
 


### PR DESCRIPTION
This is a new option for the init container to keep the secret wrapped, so it doesn't get written to the file system. This lets applications keep the secret in memory only.