### PR TITLE
Fix readme for 403 when requesting secrets

### DIFF
--- a/deployments/quick-start/README.md
+++ b/deployments/quick-start/README.md
@@ -172,7 +172,7 @@ Create a role to allow Kubernetes-Vault to generate certificates: `vault write i
 ### 2.5 Enable the AppRole backend
 Enable backend: `vault auth-enable approle`
 
-Set up an app-role for `sample-app` that generates a periodic 6 hour token: `vault write auth/approle/role/sample-app secret_id_ttl=90s period=6h secret_id_num_uses=1`
+Set up an app-role for `sample-app` that generates a periodic 6 hour token: `vault write auth/approle/role/sample-app secret_id_ttl=90s period=6h secret_id_num_uses=1 policies=kubernetes-vault`
 
 ### 2.6 Create token role for Kubernetes-Vault
 Inspect the policy file `deployments/quick-start/policy.hcl`


### PR DESCRIPTION
Fixes for this error when trying to read secrets in container.

```
E0817 01:44:26.955028       1 vault.go:154] failed to retrieve the resource: type: secret, path: secret/.... from vault, error: Error making API request.
URL: GET http://vault:8200/v1/secret/...
Code: 403. Errors:

* permission denied
```

The problem is the the role created doesn't have the policy attached.