### PR TITLE
Restructure QuickStart

### DIFF
--- a/deployments/quick-start/README.md
+++ b/deployments/quick-start/README.md
@@ -13,31 +13,32 @@ If you are using Kubernetes 1.5 and below, set the `KUBE_1_5` environment variab
 $ export KUBE_1_5=true
 ```
 
-## 1. Deploy Vault
+## 1. Vault
+
+### 1.1. Deploy
 Inspect the deployment file `deployments/quick-start/vault.yaml`. The deployment starts Vault in development mode with the root token
 set to `vault-root-token`. It is also started using `http`. In production, you should run Vault over `https`.
 
-Deploy:  ```kubectl apply -f deployments/quick-start/vault.yaml```
+Deploy: `kubectl apply -f deployments/quick-start/vault.yaml`
 
-## 2. Setup Vault
-### 2.1 Port forward vault
+### 1.2. Port forward
 Substitute the appropriate pod name for Vault: `kubectl port-forward vault-361162082-kuufw 8200`
 
-### 2.2 Set environment variables and authenticate
+### 1.3. Set environment variables and authenticate
 `set VAULT_ADDR=http://127.0.0.1:8200` for Windows
 
 `export VAULT_ADDR=http://127.0.0.1:8200` for Linux
 
 Type in the root token (`vault-root-token`) to authenticate: `vault auth`
 
-### 2.3 Set up the Root Certificate Authority
+### 1.4. Set up the Root Certificate Authority
 Create a Root CA that expires in 10 years: `vault mount -path=root-ca -max-lease-ttl=87600h pki`
 
 Generate the root certificate: `vault write root-ca/root/generate/internal common_name="Root CA" ttl=87600h exclude_cn_from_sans=true`
 
 Set up the URLs: `vault write root-ca/config/urls issuing_certificates="http://vault:8200/v1/root-ca/ca" crl_distribution_points="http://vault:8200/v1/root-ca/crl"`
 
-### 2.4 Create the Intermediate Certificate Authority
+### 1.5. Create the Intermediate Certificate Authority
 Create the Intermediate CA that expires in 5 years: `vault mount -path=intermediate-ca -max-lease-ttl=43800h pki`
 
 Generate a Certificate Signing Request: `vault write intermediate-ca/intermediate/generate/internal common_name="Intermediate CA" ttl=43800h exclude_cn_from_sans=true`
@@ -167,21 +168,21 @@ Send the stored certificate back to Vault: `vault write intermediate-ca/intermed
 
 Set up URLs: `vault write intermediate-ca/config/urls issuing_certificates="http://vault:8200/v1/intermediate-ca/ca" crl_distribution_points="http://vault:8200/v1/intermediate-ca/crl"`
 
-Create a role to allow Kubernetes-Vault to generate certificates: `vault write intermediate-ca/roles/kubernetes-vault allow_any_name=true max_ttl="24h"`
-
-### 2.5 Enable the AppRole backend
+### 1.6. Enable the AppRole backend
 Enable backend: `vault auth-enable approle`
 
-Set up an app-role for `sample-app` that generates a periodic 6 hour token: `vault write auth/approle/role/sample-app secret_id_ttl=90s period=6h secret_id_num_uses=1`
+## 2. Kubernetes-Vault
 
-### 2.6 Create token role for Kubernetes-Vault
-Inspect the policy file `deployments/quick-start/policy.hcl`
+### 2.1. Create roles and policies for Kubernetes-Vault
+Create a role to allow Kubernetes-Vault to generate certificates: `vault write intermediate-ca/roles/kubernetes-vault allow_any_name=true max_ttl="24h"`
 
-Send the policy to Vault: `vault policy-write kubernetes-vault deployments/quick-start/policy.hcl`
+Inspect the policy file `deployments/quick-start/policy-kubernetes-vault.hcl`
+
+Send the policy to Vault: `vault policy-write kubernetes-vault deployments/quick-start/policy-kubernetes-vault.hcl`
 
 Create a token role for Kubernetes-Vault that generates a 6 hour periodic token: `vault write auth/token/roles/kubernetes-vault allowed_policies=kubernetes-vault period=6h`
 
-### 2.7 Generate the token for Kubernetes-Vault and AppID
+### 2.2. Generate the token for Kubernetes-Vault
 Generate the token: `vault token-create -role=kubernetes-vault`. And make a note of the token output. In the example below it would be '00000000-1111-2222-3333-444444444444'
 
 ```
@@ -189,25 +190,14 @@ $ vault token-create -role=kubernetes-vault
 
 Key             Value
 ---             -----
-token           00000000-1111-2222-3333-444444444444      
+token           00000000-1111-2222-3333-444444444444
 token_accessor  c50fb600-aaaa-bbbb-cccc-xxxxxxxxxxxx
 token_duration  6h0m0s
 token_renewable true
 token_policies  [default kubernetes-vault]
 ```
 
-Get the app's role id: `vault read auth/approle/role/sample-app/role-id`
-```
-$ vault read auth/approle/role/sample-app/role-id
-
-Key     Value
----     -----
-role_id zzzzzzzzz-7777-8888-9999-tttttttttttt
-```
-
-## 3. Deploy Kubernetes-Vault
-### 3.1 Prepare the manifest and deploy
-
+### 2.3. Prepare the manifest and deploy
 If Kubernetes <= 1.5, use `deployments/quick-start/kubernetes-vault-kube-1.5.yaml`, otherwise use `deployments/quick-start/kubernetes-vault.yaml`.
 
 Check `deployments/quick-start/kubernetes-vault.yaml` and update the Vault token (not the role id) in the Kubernetes deployment.
@@ -233,16 +223,35 @@ If you are using Kubernetes versions >= 1.6, make sure you modify the namespaces
 
 Deploy: `kubectl apply -f deployments/quick-start/kubernetes-vault.yaml`
 
-### 3.2 Confirm Kubernetes-Vault deployed successfully
+### 2.4. Confirm Kubernetes-Vault deployed successfully
 Use the Kubernetes dashboard to view the status of the deployment and make sure all pods are healthy.
 
-## 4. Deploy a sample app
-### 4.1 Prepare the manifest and deploy
+## 3. Sample app
+
+### 3.1. Set up an app-role
+Set up an app-role for `sample-app` that generates a periodic 6 hour token: `vault write auth/approle/role/sample-app secret_id_ttl=90s period=6h secret_id_num_uses=1`
+
+### 3.2. Add new rules to kubernetes-vault policy
+Read existing rules from kubernetes-vault policy, add rules from file policy-sample-app.hcl, and write combined set of rules back to kubernetes-vault policy
+```
+current_rules="$(vault read -format=json sys/policy/kubernetes-vault | jq -r .data.rules)"
+app_rules="$(cat policy-sample-app.hcl)"
+echo -e "$current_rules\n\n$app_rules" | vault write sys/policy/kubernetes-vault rules=-
+```
+
+### 3.3. Prepare the manifest and deploy the app
+Get the app's role id: `vault read auth/approle/role/sample-app/role-id`
+```
+$ vault read auth/approle/role/sample-app/role-id
+
+Key     Value
+---     -----
+role_id zzzzzzzzz-7777-8888-9999-tttttttttttt
+```
 
 If Kubernetes <= 1.5, use `deployments/quick-start/sample-app-kube-1.5.yaml`, otherwise use `deployments/quick-start/sample-app.yaml`.
 
 Inspect `deployments/quick-start/sample-app.yaml` and update the role id in the deployment:
-
 ```
 ...
 spec:
@@ -278,7 +287,7 @@ spec:
 
 Deploy: `kubectl apply -f deployments/quick-start/sample-app.yaml`
 
-## 5. Confirm that each pod of the sample app received a Vault token
+## 4. Confirm that each pod of the sample app received a Vault token
 View the logs using the Kubernetes dashboard or `kubectl logs mypod` and confirm that each pod receive a token.
 The token and various other information related to the token should be logged.
 
@@ -289,8 +298,8 @@ policy. In production, you should set appropriate policies for the app-role when
 you SHOULD have a separate AppRole for each app with appropriate policies to restrict access to the secret tree for each app.
 Simply create as many AppRoles as required and set the appropriate `app-id` in the Kubernetes-Vault init-container for each app.
 
-## 6. Tear down
-Clean up: `kubectl delete -f deployments/quick-start/sample-app.yaml -f deployments/quick-start/kubernetes-vault.yaml`
+## Tear down
+Clean up: `kubectl delete -f deployments/quick-start/sample-app.yaml -f deployments/quick-start/kubernetes-vault.yaml -f deployments/quick-start/vault.yaml`
 
 ## Further deployment options
 In this guide, we did not set up TLS client authentication for the metrics endpoint. To do so, simply set the `vaultCABackends`

--- a/deployments/quick-start/policy-kubernetes-vault.hcl
+++ b/deployments/quick-start/policy-kubernetes-vault.hcl
@@ -2,10 +2,6 @@ path "intermediate-ca/issue/kubernetes-vault" {
   capabilities = ["update"]
 }
 
-path "auth/approle/role/sample-app/secret-id" {
-  capabilities = ["update"]
-}
-
 path "auth/token/roles/kubernetes-vault" {
   capabilities = ["read"]
 }

--- a/deployments/quick-start/policy-sample-app.hcl
+++ b/deployments/quick-start/policy-sample-app.hcl
@@ -1,0 +1,3 @@
+path "auth/approle/role/sample-app/secret-id" {
+  capabilities = ["update"]
+}

--- a/deployments/quick-start/setup.sh
+++ b/deployments/quick-start/setup.sh
@@ -82,9 +82,11 @@ vault write -format=json intermediate-ca/intermediate/generate/internal \
 vault write -format=json root-ca/root/sign-intermediate \
     csr=@intermediate.csr use_csr_values=true exclude_cn_from_sans=true \
     | jq -r .data.certificate > signed.crt
+rm -f intermediate.csr
 
 # Send the stored certificate back to Vault:
 vault write intermediate-ca/intermediate/set-signed certificate=@signed.crt
+rm -f signed.crt
 
 # Set up URLs:
 vault write intermediate-ca/config/urls issuing_certificates="http://vault:8200/v1/intermediate-ca/ca" \

--- a/deployments/quick-start/setup.sh
+++ b/deployments/quick-start/setup.sh
@@ -9,8 +9,9 @@ do
     fi
 done
 
-# 1. Deploy Vault
+# 1. Vault
 
+# 1.1. Deploy
 # Inspect the deployment file deployments/quick-start/vault.yaml. The deployment starts Vault in development mode with
 # the root token set to vault-root-token. It is also started using http. In production, you should run Vault over https.
 kubectl apply -f vault.yaml
@@ -47,18 +48,16 @@ then
     exit 1
 fi
 
-# 2. Setup Vault
-
-# 2.1 Port forward vault
+# 1.2. Port forward
 nohup kubectl port-forward $vaultPod 8200 &
 echo "Waiting for port forwarding to start"
 sleep 3
 
-# 2.2 Set environment variables and authenticate
+# 1.3. Set environment variables and authenticate
 export VAULT_ADDR=http://127.0.0.1:8200
 vault auth vault-root-token
 
-# 2.3 Set up the Root Certificate Authority
+# 1.4. Set up the Root Certificate Authority
 # Create a Root CA that expires in 10 years:
 vault mount -path=root-ca -max-lease-ttl=87600h pki
 
@@ -69,7 +68,7 @@ vault write root-ca/root/generate/internal common_name="Root CA" ttl=87600h excl
 vault write root-ca/config/urls issuing_certificates="http://vault:8200/v1/root-ca/ca" \
     crl_distribution_points="http://vault:8200/v1/root-ca/crl"
 
-# 2.4 Create the Intermediate Certificate Authority
+# 1.5. Create the Intermediate Certificate Authority
 # Create the Intermediate CA that expires in 5 years:
 vault mount -path=intermediate-ca -max-lease-ttl=43800h pki
 
@@ -92,31 +91,30 @@ rm -f signed.crt
 vault write intermediate-ca/config/urls issuing_certificates="http://vault:8200/v1/intermediate-ca/ca" \
     crl_distribution_points="http://vault:8200/v1/intermediate-ca/crl"
 
+# 1.6. Enable the AppRole backend
+vault auth-enable approle
+
+# 2. Kubernetes-Vault
+
+# 2.1. Create roles and policies for Kubernetes-Vault
+
 # Create a role to allow Kubernetes-Vault to generate certificates:
 vault write intermediate-ca/roles/kubernetes-vault allow_any_name=true max_ttl="24h"
 
-# 2.5 Enable the AppRole backend
-
-# Enable backend:
-vault auth-enable approle
-
-# Set up an app-role for sample-app that generates a periodic 6 hour token:
-vault write auth/approle/role/sample-app secret_id_ttl=90s period=6h secret_id_num_uses=1
-
-# 2.6 Create token role for Kubernetes-Vault
-
-# Inspect the policy file deployments/quick-start/policy.hcl
+# Inspect the policy file deployments/quick-start/policy-kubernetes-vault.hcl
 
 # Send the policy to Vault:
-vault policy-write kubernetes-vault policy.hcl
+vault policy-write kubernetes-vault policy-kubernetes-vault.hcl
 
 # Create a token role for Kubernetes-Vault that generates a 6 hour periodic token:
 vault write auth/token/roles/kubernetes-vault allowed_policies=kubernetes-vault period=6h
 
-# 2.7 Generate the token for Kubernetes-Vault and AppID
+# 2.2. Generate the token for Kubernetes-Vault and AppID
 
 # Generate the token:
 CLIENTTOKEN=$(vault token-create -format=json -role=kubernetes-vault | jq -r .auth.client_token)
+
+# 2.3. Prepare the manifest and deploy
 
 KUBERNETES_VAULT_DEPLOYMENT="kubernetes-vault.yaml"
 
@@ -126,9 +124,27 @@ fi
 
 sed -i -e "s/token\: .*$/token: $CLIENTTOKEN/g" $KUBERNETES_VAULT_DEPLOYMENT
 
-# Get the AppID:
-# vault read auth/approle/role/sample-app/role-id
+# Deploy
+kubectl apply -f $KUBERNETES_VAULT_DEPLOYMENT
+
+# 3. Sample app
+
+# 3.1. Set up an app-role
+
+# Set up an app-role for sample-app that generates a periodic 6 hour token:
+vault write auth/approle/role/sample-app secret_id_ttl=90s period=6h secret_id_num_uses=1
+
+# 3.2. Add new rules to kubernetes-vault policy
+current_rules="$(vault read -format=json sys/policy/kubernetes-vault | jq -r .data.rules)"
+app_rules="$(cat policy-sample-app.hcl)"
+echo "$current_rules\n\n$app_rules" | vault write sys/policy/kubernetes-vault rules=-
+
+# 3.3. Prepare the manifest and deploy the app
+
+# Get the app’s role id:
 ROLEID=$(vault read -format=json auth/approle/role/sample-app/role-id | jq -r .data.role_id)
+
+# Inspect deployments/quick-start/sample-app.yaml and update the role id in the deployment
 
 SAMPLE_APP_DEPLOYMENT="sample-app.yaml"
 
@@ -139,20 +155,10 @@ else
     sed -i -e "s/value\: .*$/value: $ROLEID/g" $SAMPLE_APP_DEPLOYMENT
 fi
 
-# 3. Deploy Kubernetes-Vault
-
-# 3.1 Prepare the manifest and deploy
-
-# Check deployments/quick-start/kubernetes-vault.yaml and update the Vault token in the Kubernetes deployment.
-kubectl apply -f $KUBERNETES_VAULT_DEPLOYMENT
-
-# 4. Deploy a sample app
-
-# 4.1 Prepare the manifest and deploy
-
-# Inspect deployments/quick-start/sample-app.yaml and update the role id in the deployment.
+# Deploy
 kubectl apply -f $SAMPLE_APP_DEPLOYMENT
 
-# 5. Confirm that each pod of the sample app received a Vault token
-echo View the logs using the Kubernetes dashboard or kubectl logs mypod and confirm that each pod receive a token. \
-The token and various other information related to the token should be logged.
+# 4. Confirm that each pod of the sample app received a Vault token
+echo "\nView the logs using the Kubernetes dashboard or kubectl logs mypod
+and confirm that each pod receive a token. The token and various other
+information related to the token should be logged."

--- a/deployments/quick-start/teardown.sh
+++ b/deployments/quick-start/teardown.sh
@@ -14,4 +14,4 @@ fi
 
 kubectl delete -f $SAMPLE_APP_DEPLOYMENT -f $KUBERNETES_VAULT_DEPLOYMENT -f vault.yaml
 ps -ef | grep "kubectl port-forward" | grep 8200 |awk '{print $2}'|xargs kill
-rm intermediate.csr signed.crt nohup.out
+rm nohup.out

--- a/deployments/quick-start/teardown.sh
+++ b/deployments/quick-start/teardown.sh
@@ -13,5 +13,8 @@ if [ "$KUBE_1_5" = true ]; then
 fi
 
 kubectl delete -f $SAMPLE_APP_DEPLOYMENT -f $KUBERNETES_VAULT_DEPLOYMENT -f vault.yaml
-ps -ef | grep "kubectl port-forward" | grep 8200 |awk '{print $2}'|xargs kill
-rm nohup.out
+pid=$(ps -ef | grep "kubectl port-forward" | grep 8200 | awk '{print $2}')
+if [ ! -z $pid ]; then
+    kill $pid
+fi
+rm -f nohup.out


### PR DESCRIPTION
I've made some changes in QuickStart structure. Basically I've made a separate section which describes sample-app deployment. Now it's easier to see where the infrastructure is prepared and where the app is deployed. And you can just skip the last step to deploy kubernetes-vault and then repeat the last step for each of your own applications.

Maybe it is a good idea to split `deployments/quick-start/setup.sh` into something like `setup-vault.sh` and `setup-simple-app.sh`. What do you think?