### PR TITLE
add skipTokenRoleNameValidation parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ The address of the Vault server. For example, `http://vault:8200`.
 * token *(required)*
 A renewable and periodic Vault token to be used by the Kubernetes-Vault controller.
 
+* skipTokenRoleNameValidation *(optional)*
+If set to `true` then skip validation for token role name. By default, this is: `false`.
+
 * tls *(optional)*
 If Vault is secured using TLS (https), then you need to set one of the following:
 

--- a/cmd/controller/root.go
+++ b/cmd/controller/root.go
@@ -35,6 +35,7 @@ type config struct {
 	Vault struct {
 		Addr  string `mapstructure:"addr"`
 		Token string `mapstructure:"token"`
+		SkipTokenRoleNameValidation bool `mapstructure:"skipTokenRoleNameValidation"`
 		TLS   struct {
 			VaultCABackends []string `mapstructure:"vaultCABackends"`
 			CACert          string   `mapstructure:"caCert"`
@@ -238,7 +239,7 @@ var RootCmd = &cobra.Command{
 			}
 		}
 
-		vault, err := client.NewVault(conf.Vault.Addr, conf.Vault.Token, conf.Kubernetes.Service, conf.Vault.WrappingTTL, rootCAResolver, logger)
+		vault, err := client.NewVault(conf.Vault.Addr, conf.Vault.Token, conf.Vault.SkipTokenRoleNameValidation, conf.Kubernetes.Service, conf.Vault.WrappingTTL, rootCAResolver, logger)
 
 		if err != nil {
 			logger.Fatalf("Could not create the vault client: %s", err)


### PR DESCRIPTION
Description:
Add new parameter skipTokenRoleNameValidation to skip role name validation.

Root Cause:
In some case users might want to use token that generate from other authentication such as LDAP but error always thrown at code
```
		// There must be a valid role
		if data.Role == "" {
			multierror.Append(&mErr, errors.New("token role name must be set when not using a root token"))
		}

		if err := v.validateRole(data.Role); err != nil {
			multierror.Append(&mErr, err)
		}
```
